### PR TITLE
docs: remove specific market size reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## 🌟 What is Xend Network?
 
-Xend Network revolutionizes the $25.46B tokenized Real World Asset (RWA) market by providing the complete financial ecosystem that investors and consumer need. Unlike existing solutions that focus solely on tokenization, Xend Network combines advanced AI analytics with professional financial services to deliver:
+Xend Network revolutionizes Real World Asset (RWA) market by providing the complete financial ecosystem that investors and consumer need. Unlike existing solutions that focus solely on tokenization, Xend Network combines advanced AI analytics with professional financial services to deliver:
 
 **🤖 AI-Powered Intelligence**: Advanced algorithms continuously scan global markets, analyze thousands of real-world assets, and provide personalized investment recommendations with predictive modeling and sentiment analysis.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the opening description of the Real World Asset (RWA) market by removing the dollar-value market size and tokenization qualifiers, and refining phrasing for clarity and neutrality.
  * Preserves the document’s intent and scope while improving readability and timelessness.
  * No user-facing behavior or functionality impacted; the remainder of the documentation is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->